### PR TITLE
Wrap another line in `unsafe`

### DIFF
--- a/examples/string_arguments/src/lib.rs
+++ b/examples/string_arguments/src/lib.rs
@@ -6,8 +6,12 @@ use std::str;
 
 #[no_mangle]
 pub extern fn how_many_characters(s: *const c_char) -> uint32_t {
-    assert!(!s.is_null());
-    let c_str = unsafe { CStr::from_ptr(s) };
+    let c_str = unsafe {
+        assert!(!s.is_null());
+        
+        CStr::from_ptr(s)
+    };
+    
     let r_str = str::from_utf8(c_str.to_bytes()).unwrap();
     r_str.chars().count() as uint32_t
 }


### PR DESCRIPTION
It's generally better to include everything that makes a particular `unsafe` block safe within the block. Just wrapping a single function call in `unsafe` doesn't give you information about what you've done to make it safe.

In this case, we ensure that the string isn't null, and so that makes it safe to call `from_ptr`.