### PR TITLE
Added Haskell (GHC) FFI examples

### DIFF
--- a/examples/integers/src/main.hs
+++ b/examples/integers/src/main.hs
@@ -1,0 +1,8 @@
+{-# LANGUAGE ForeignFunctionInterface #-}
+
+import Foreign.C.Types (CUInt(..))
+
+foreign import ccall "addition" addition :: CUInt -> CUInt -> CUInt
+
+main :: IO ()
+main = print (addition 1 2)

--- a/examples/integers/src/main.hs
+++ b/examples/integers/src/main.hs
@@ -1,8 +1,9 @@
 {-# LANGUAGE ForeignFunctionInterface #-}
 
-import Foreign.C.Types (CUInt(..))
+import Data.Word (Word32)
 
-foreign import ccall "addition" addition :: CUInt -> CUInt -> CUInt
+foreign import ccall "addition"
+  addition :: Word32 -> Word32 -> Word32
 
 main :: IO ()
 main = print (addition 1 2)

--- a/examples/slice_arguments/src/main.hs
+++ b/examples/slice_arguments/src/main.hs
@@ -1,11 +1,11 @@
 {-# LANGUAGE ForeignFunctionInterface #-}
 
+import Data.Word (Word32)
 import Foreign (Ptr)
-import Foreign.C.Types (CUInt(..))
 import Foreign.Marshal.Array (withArrayLen)
 
 foreign import ccall "sum_of_even"
-  sum_of_even :: Ptr CUInt -> CUInt -> CUInt
+  sum_of_even :: Ptr Word32 -> Word32 -> Word32
 
 main :: IO ()
 main = withArrayLen [1,2,3,4,5,6] $ \len arr ->

--- a/examples/slice_arguments/src/main.hs
+++ b/examples/slice_arguments/src/main.hs
@@ -1,0 +1,12 @@
+{-# LANGUAGE ForeignFunctionInterface #-}
+
+import Foreign (Ptr)
+import Foreign.C.Types (CUInt(..))
+import Foreign.Marshal.Array (withArrayLen)
+
+foreign import ccall "sum_of_even"
+  sum_of_even :: Ptr CUInt -> CUInt -> CUInt
+
+main :: IO ()
+main = withArrayLen [1,2,3,4,5,6] $ \len arr ->
+    print (sum_of_even arr (fromIntegral len))

--- a/examples/string_arguments/src/main.hs
+++ b/examples/string_arguments/src/main.hs
@@ -1,0 +1,12 @@
+{-# LANGUAGE ForeignFunctionInterface #-}
+
+import Foreign.C.String (CString(..), newCString)
+import Foreign.C.Types (CUInt(..))
+
+foreign import ccall "how_many_characters"
+  how_many_characters :: CString -> CUInt
+
+main :: IO ()
+main = do
+  str <- newCString "göes to élevên"
+  print (how_many_characters str)

--- a/examples/string_arguments/src/main.hs
+++ b/examples/string_arguments/src/main.hs
@@ -1,10 +1,10 @@
 {-# LANGUAGE ForeignFunctionInterface #-}
 
+import Data.Word (Word32)
 import Foreign.C.String (CString(..), newCString)
-import Foreign.C.Types (CUInt(..))
 
 foreign import ccall "how_many_characters"
-  how_many_characters :: CString -> CUInt
+  how_many_characters :: CString -> Word32
 
 main :: IO ()
 main = do

--- a/site/basics/index.md
+++ b/site/basics/index.md
@@ -33,6 +33,11 @@ All Ruby examples will use Ruby 2.2 and the [FFI gem][gem].
 
 All Python examples will use Python 2.7 and the [ctypes library][ctypes].
 
+## Haskell
+
+All Haskell examples will use GHC 7.10 with the `ForeignFunctionInterface`
+language extension and only the `base` library which comes with GHC.
+
 [official]: https://doc.rust-lang.org/book/ffi.html
 [Cargo]: https://crates.io/
 [libc]: http://doc.rust-lang.org/libc/libc/index.html

--- a/site/integers/index.md
+++ b/site/integers/index.md
@@ -41,3 +41,19 @@ This can be run with `LD_LIBRARY_PATH=target/debug/ ruby
 {% example src/main.py %}
 
 This can be run with `LD_LIBRARY_PATH=target/debug python src/main.py`.
+
+## Haskell
+
+{% example src/main.hs %}
+
+We have to enable the `ForeignFunctionInterface` language extension and
+import the relevant low-level types before we can include a
+`foreign import` declaration. This includes the calling convention
+(`ccall`), the symbol name (`"addition"`), the corresponding Haskell
+name (`addition`), and the type of the function. This function is
+effectively pure, so we don't include `IO` in the type, but an
+observably impure function would want to return an `IO` value to
+indicate that it has side-effects.
+
+This can be compiled using
+`ghc src/main.hs target/debug/libintegers.so -o haskell-example`.

--- a/site/slice_arguments/index.md
+++ b/site/slice_arguments/index.md
@@ -50,3 +50,15 @@ store our integers. Once created, we copy the values into it using
 Calling from Python requires more work than previous examples. This
 time, we create a new type to store our integers and instantiate the
 type using the values.
+
+## Haskell
+
+{% example src/main.hs %}
+
+For this example, we can use the `withArrayLen` function, which takes
+a Haskell array whose contents are `Storable` (i.e. serializable to
+byte sequences that C can understand) and produces a packed array of
+those values, which it then passes, along with the array's length, to
+a callback function. In this case, it passes the array's length as
+type `Int`, which we convert into the expected `CUInt` type using
+the `fromIntegral` function.

--- a/site/string_arguments/index.md
+++ b/site/string_arguments/index.md
@@ -70,3 +70,12 @@ string.
 
 The ctypes library automatically converts Python strings to the
 appropriate C string.
+
+## Haskell
+
+{% example src/main.hs %}
+
+The `Foreign.C.String` module has support for converting Haskell's
+string representation to C's packed-byte representation. We can
+create one with the `newCString` function, and then pass the
+`CString` value to our foreign call.


### PR DESCRIPTION
I've added a small Haskell equivalent to each of the three current examples. They've been tested now with both GHC 7.8 and 7.1-. They only rely on the `base` library that comes with GHC, so they should be relatively stable across a wide swath of GHC versions.

Using only `base` for dependencies was a deliberate choice, as there are other possible ways of writing these programs using other libraries. For example, I used the representation of C arrays from `base`, but there are other array representations in Haskell (such as the `vector` and `array` packages) which a programmer might use instead. Similarly, I used the built-in `String` type, but a programmer may prefer to use the `text` package when working with textual data. I reasoned that using only the built-in data representations would demonstrate the basics of using the FFI with no other complications.

I've included source files and textual descriptions for the site portion. I wasn't sure if there was anything I should add to the Makefiles or other areas to support adding the Haskell sources, so let me know if I need to add anything else!