### PR TITLE
Fix examples for Windows.

### DIFF
--- a/examples/integers/src/lib.rs
+++ b/examples/integers/src/lib.rs
@@ -5,3 +5,7 @@ use libc::uint32_t;
 pub extern fn addition(a: uint32_t, b: uint32_t) -> uint32_t {
     a + b
 }
+
+#[allow(dead_code)]
+#[cfg(windows)]
+fn fix_windows_linking() { panic!() }

--- a/examples/integers/src/main.py
+++ b/examples/integers/src/main.py
@@ -1,8 +1,10 @@
+#!/usr/bin/env python2
 import sys, ctypes
 from ctypes import c_uint32
 
-extension = '.dylib' if sys.platform == 'darwin' else '.so'
-lib = ctypes.cdll.LoadLibrary("libintegers" + extension)
+prefix = {'win32': ''}.get(sys.platform, 'lib')
+extension = {'darwin': '.dylib', 'win32': '.dll'}.get(sys.platform, '.so')
+lib = ctypes.cdll.LoadLibrary(prefix + "integers" + extension)
 
 lib.addition.argtypes = (c_uint32, c_uint32)
 lib.addition.restype = c_uint32

--- a/examples/slice_arguments/src/main.py
+++ b/examples/slice_arguments/src/main.py
@@ -1,8 +1,10 @@
+#!/usr/bin/env python2
 import sys, ctypes
 from ctypes import POINTER, c_uint32, c_size_t
 
-extension = '.dylib' if sys.platform == 'darwin' else '.so'
-lib = ctypes.cdll.LoadLibrary("libslice_arguments" + extension)
+prefix = {'win32': ''}.get(sys.platform, 'lib')
+extension = {'darwin': '.dylib', 'win32': '.dll'}.get(sys.platform, '.so')
+lib = ctypes.cdll.LoadLibrary(prefix + "slice_arguments" + extension)
 
 lib.sum_of_even.argtypes = (POINTER(c_uint32), c_size_t)
 lib.sum_of_even.restype = ctypes.c_uint32

--- a/examples/string_arguments/src/main.py
+++ b/examples/string_arguments/src/main.py
@@ -1,9 +1,11 @@
+#!/usr/bin/env python2
 # coding: utf-8
 import sys, ctypes
 from ctypes import c_uint32, c_char_p
 
-extension = '.dylib' if sys.platform == 'darwin' else '.so'
-lib = ctypes.cdll.LoadLibrary("libstring_arguments" + extension)
+prefix = {'win32': ''}.get(sys.platform, 'lib')
+extension = {'darwin': '.dylib', 'win32': '.dll'}.get(sys.platform, '.so')
+lib = ctypes.cdll.LoadLibrary(prefix + "string_arguments" + extension)
 
 lib.how_many_characters.argtypes = (c_char_p,)
 lib.how_many_characters.restype = c_uint32


### PR DESCRIPTION
This fixes a linking issue with integers, and updates the Python code
to run the correct interpreter and use the proper DLL names.

# `integers`

The problem here is that, on Windows, if you don't use any symbols from
the standard library *and* create a dynamic library, linking will fail.
This is a known issue (rust-lang/rust#18807) and the only half-way decent
solution is to include a dead function that *does* use something from the
standard library.

# Python

Two changes.  First, I've added a hashbang to invoke the correct Python
interpreter.  On Windows, it's common to execute scripts directly without
specifying the interpreter.  In addition, it is *not* common to have
multiple versions of Python accessible on the PATH at one time.  As such,
Python on Windows comes with a "launcher" that reads the hashbang and
executes the appropriate version of Python.

Anyone with Python 3.x installed will almost certainly have *that* as the
default, so indicating that the script needs Python 2.x specifically is
a really good idea.

Also, the existing examples do not correctly determine the name of the
Windows libraries being loaded.  Two things: they end in `.dll` and they
*do not* start with `lib`.

# Miscellaneous

I have made no attempt to get these working on Windows, as the examples just immediately segfault for no apparent reason and, to be honest, I don't care enough about Ruby to work out why.  :P

I'm also working on doc changes separately.