### PR TITLE
Updated the docs to mention Windows.

### DIFF
--- a/site/basics/index.md
+++ b/site/basics/index.md
@@ -38,6 +38,24 @@ All Python examples will use Python 2.7 and the [ctypes library][ctypes].
 All Haskell examples will use GHC 7.10 with the `ForeignFunctionInterface`
 language extension and only the `base` library which comes with GHC.
 
+## Running Examples
+
+When running examples, you need to ensure the Rust dynamic library
+can be located by the system.
+
+With most shells on Mac OS X and Linux, this can be done by prefixing
+commands with `LD_LIBRARY_PATH=target/debug`.  For example, to run a
+Python example, you might use
+`LD_LIBRARY_PATH=target/debug python src/main.py` from the example
+directory.
+
+On Windows, the simplest course of action is to copy the compiled
+dynamic library into the current working directory before running the
+examples.  You only need the `.dll` file.  Also note that when
+running Python examples, you may wish to use `py` instead of
+`python`, especially if you have multiple versions of Python
+installed.
+
 [official]: https://doc.rust-lang.org/book/ffi.html
 [Cargo]: https://crates.io/
 [libc]: http://doc.rust-lang.org/libc/libc/index.html

--- a/site/integers/index.md
+++ b/site/integers/index.md
@@ -14,11 +14,11 @@ two signed 32-bit numbers.
 Compile this with `cargo build`, which will produce a library in
 `target/debug/`. The exact filename depends on your platform:
 
-| Platform | Extension |
-|----------|-----------|
-| Windows  | .dll      |
-| OS X     | .dylib    |
-| Linux    | .so       |
+| Platform | Pattern    |
+|----------|------------|
+| Windows  | *.dll      |
+| OS X     | lib*.dylib |
+| Linux    | lib*.so    |
 
 ## C
 
@@ -28,6 +28,11 @@ We start by declaring an `extern` function with the proper argument
 and return types. This can then be compiled and linked against the
 Rust library using `gcc --std=c11 -o c-example src/main.c -L
 target/debug/ -lintegers`.
+
+As noted in the basics section, this can be run on Mac OS X and Linux
+with `LD_LIBRARY_PATH=target/debug/ ./c-example`, and on Windows by
+copying `target\debug\integers.dll` to the current directory and
+running `.\c-example`.
 
 ## Ruby
 
@@ -40,7 +45,10 @@ This can be run with `LD_LIBRARY_PATH=target/debug/ ruby
 
 {% example src/main.py %}
 
-This can be run with `LD_LIBRARY_PATH=target/debug python src/main.py`.
+As noted in the basics section, this can be run on Mac OS X and Linux
+with `LD_LIBRARY_PATH=target/debug/ python src/main.py`, and on
+Windows by copying `target\debug\integers.dll` to the current
+directory and running `py src\main.py`.
 
 ## Haskell
 


### PR DESCRIPTION
I added an explanatory section to "basics", and bulked out the comments
in the "integers" example.

Note that I have *not* adjusted the Ruby instructions as I don't use
Ruby and can't verify their correctness.

These changes lean *slightly* on #14 but should be usable independently.