### PR TITLE
Add node.js examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,7 @@ addons:
       - ghc
 before_install:
 - bundle install
-- cd examples && bundle install ; cd ..
-- npm install ffi ref ref-array
+- cd examples && bundle install ; npm install ; cd ..
 script:
 - make -C examples
 - cd site && jekyll build --destination ../built-site --config _config.yml,_config.prod.yml; cd ..

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ addons:
 before_install:
 - bundle install
 - cd examples && bundle install ; cd ..
+- npm install ffi ref ref-array
 script:
 - make -C examples
 - cd site && jekyll build --destination ../built-site --config _config.yml,_config.prod.yml; cd ..

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -18,6 +18,7 @@ TEST_C := tests_c.mk
 TEST_RUBY := tests_ruby.mk
 TEST_PYTHON := tests_python.mk
 TEST_HASKELL := tests_haskell.mk
+TEST_NODEJS := tests_nodejs.mk
 TEST_ALL_LANGUAGES := tests_all.mk
 
 dir := integers
@@ -29,7 +30,7 @@ include ${dir}/rules.mk
 dir := tuples
 include ${dir}/rules.mk
 
-all: c ruby python haskell
+all: c ruby python haskell nodejs
 .PHONY: all
 
 # Test only a single language
@@ -41,5 +42,6 @@ c:
 ruby:
 python:
 haskell:
+nodejs:
 
-.PHONY: c ruby python haskell
+.PHONY: c ruby python haskell nodejs

--- a/examples/integers/src/main.js
+++ b/examples/integers/src/main.js
@@ -1,0 +1,7 @@
+var ffi = require('ffi');
+
+var lib = ffi.Library('libintegers', {
+    'addition': ['uint32', ['uint32', 'uint32']]
+});
+
+console.log(lib.addition(1, 2));

--- a/examples/package.json
+++ b/examples/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "rust-ffi-omnibus",
+  "version": "0.0.0",
+  "description": " A collection of examples of using code written in Rust from other languages",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "Jake Goulding",
+  "license": "MIT",
+  "private": true,
+  "dependencies": {
+    "ffi": "^1.3.1",
+    "ref": "^1.0.2",
+    "ref-array": "^1.1.1"
+  }
+}

--- a/examples/package.json
+++ b/examples/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "ffi": "^1.3.1",
     "ref": "^1.0.2",
-    "ref-array": "^1.1.1"
+    "ref-array": "^1.1.1",
+    "ref-struct": "^1.0.1"
   }
 }

--- a/examples/slice_arguments/src/main.js
+++ b/examples/slice_arguments/src/main.js
@@ -1,0 +1,12 @@
+var ffi = require('ffi');
+var ref = require('ref');
+var array = require('ref-array');
+
+var u32array = array(ref.types.uint32);
+
+var lib = ffi.Library('libslice_arguments', {
+    'sum_of_even': ['uint32', [u32array, 'size_t']]
+});
+
+var numbers = new u32array([1, 2, 3, 4, 5, 6]);
+console.log(lib.sum_of_even(numbers, numbers.length));

--- a/examples/string_arguments/src/main.js
+++ b/examples/string_arguments/src/main.js
@@ -1,0 +1,7 @@
+var ffi = require('ffi');
+
+var lib = ffi.Library('libstring_arguments', {
+    'how_many_characters': ['uint32', ['string']]
+});
+
+console.log(lib.how_many_characters('göes to élevên'));

--- a/examples/tests_all.mk
+++ b/examples/tests_all.mk
@@ -2,3 +2,4 @@ include ${TEST_C}
 include ${TEST_RUBY}
 include ${TEST_PYTHON}
 include ${TEST_HASKELL}
+include ${TEST_NODEJS}

--- a/examples/tests_nodejs.mk
+++ b/examples/tests_nodejs.mk
@@ -1,0 +1,13 @@
+include ${COMMON_TEST_RULES}
+
+${TEST_DIR_${d}}/nodejs-test: LIB_DIR := ${LIB_DIR_${d}}
+${TEST_DIR_${d}}/nodejs-test: ${d}/src/main.js ${TEST_DIR_${d}} ${LIB_${d}}
+	LD_LIBRARY_PATH=${LIB_DIR} node $< > $@
+
+.PHONY: nodejs-test_${d}
+nodejs-test_${d}: EXPECTED := ${d}/expected-output
+nodejs-test_${d}: ${TEST_DIR_${d}}/nodejs-test
+	diff -q ${EXPECTED} $<
+
+nodejs: nodejs-test_${d}
+

--- a/examples/tuples/rules.mk
+++ b/examples/tuples/rules.mk
@@ -6,6 +6,7 @@ LIB_NAME_${d} := tuples
 include ${TEST_C}
 include ${TEST_RUBY}
 include ${TEST_PYTHON}
+include ${TEST_NODEJS}
 
 d  := ${dirstack_${sp}}
 sp := ${basename ${sp}}

--- a/examples/tuples/src/main.js
+++ b/examples/tuples/src/main.js
@@ -1,0 +1,16 @@
+var ffi = require('ffi');
+var ref = require('ref');
+var struct = require('ref-struct');
+
+var Tuple = struct({
+    x: 'uint32',
+    y: 'uint32'
+});
+
+var lib = ffi.Library('libtuples', {
+    'flip_things_around': [Tuple, [Tuple]]
+});
+
+var tup = new Tuple({x: 10, y: 20});
+var result = lib.flip_things_around(tup);
+console.log("(%d,%d)", result.x, result.y);

--- a/site/basics/index.md
+++ b/site/basics/index.md
@@ -38,9 +38,14 @@ All Python examples will use Python 2.7 and the [ctypes library][ctypes].
 All Haskell examples will use GHC 7.10 with the `ForeignFunctionInterface`
 language extension and only the `base` library which comes with GHC.
 
+## Node.js
+
+All node.js examples will use node 0.12 and the [ffi package][node-ffi].
+
 [official]: https://doc.rust-lang.org/book/ffi.html
 [Cargo]: https://crates.io/
 [libc]: http://doc.rust-lang.org/libc/libc/index.html
 [dyn-stat]: http://doc.crates.io/manifest.html#building-dynamic-or-static-libraries
 [gem]: https://github.com/ffi/ffi
 [ctypes]: https://docs.python.org/2/library/ctypes.html
+[node-ffi]: https://www.npmjs.com/package/node-ffi

--- a/site/integers/index.md
+++ b/site/integers/index.md
@@ -57,3 +57,14 @@ indicate that it has side-effects.
 
 This can be compiled using
 `ghc src/main.hs target/debug/libintegers.so -o haskell-example`.
+
+## Node.js
+
+{% example src/main.js %}
+
+The `Library` function specifies the name of a dynamic library to link with,
+along with a list of exported functions' signatures (in the form of
+`function_name: [return_type, [argument_types]]`). These functions are then
+available as methods of the object returned by `Library`.
+
+This can be run with `LD_LIBRARY_PATH=target/debug node src/main.js`.

--- a/site/slice_arguments/index.md
+++ b/site/slice_arguments/index.md
@@ -62,3 +62,15 @@ those values, which it then passes, along with the array's length, to
 a callback function. In this case, it passes the array's length as
 type `Int`, which we convert into the expected `CUInt` type using
 the `fromIntegral` function.
+
+## Node.js
+
+{% example src/main.js %}
+
+We need to use the [`ref`][ref] and [`ref-array`][ref-array] packages
+to wrap node.js memory buffers into array-like objects which can be easily
+manipulated from JavaScript. The `u32array` type (constructed using
+primitives from `ref.types`) can be then used in function signatures.
+
+[ref]: https://www.npmjs.com/package/ref
+[ref-array]: https://www.npmjs.com/package/ref-array

--- a/site/string_arguments/index.md
+++ b/site/string_arguments/index.md
@@ -79,3 +79,10 @@ The `Foreign.C.String` module has support for converting Haskell's
 string representation to C's packed-byte representation. We can
 create one with the `newCString` function, and then pass the
 `CString` value to our foreign call.
+
+## Node.js
+
+{% example src/main.js %}
+
+The `ffi` package automatically converts JavaScript strings to the
+appropriate C strings.

--- a/site/tuples/index.md
+++ b/site/tuples/index.md
@@ -51,3 +51,12 @@ types.
 
 Unfortunately, Haskell does not currently support passing or returning
 arbitrary structs. Pointer indirection is always required.
+
+## Node.js
+
+{% example src/main.js %}
+
+The [`ref-struct`][ref-struct] package allows us to build struct types
+which can be passed to FFI functions.
+
+[ref-struct]: https://www.npmjs.com/package/ref-struct


### PR DESCRIPTION
I'm adding examples of node.js bindings using [ffi](https://www.npmjs.com/package/ffi). Don't merge yet - this is a work in progress and needs Travis integration and at least a few words of documentation on the Jekyll site. I'll focus on that next and will update this PR later.