### PR TITLE
uint32_t is unsigned

### DIFF
--- a/site/integers/index.md
+++ b/site/integers/index.md
@@ -8,7 +8,7 @@ title: Integers
 
 Integers are the "hello world!" of FFI, as they are generally much
 easier to pass across the boundary. Let's create a library that adds
-two signed 32-bit numbers.
+two unsigned 32-bit numbers.
 
 {% example src/lib.rs %}
 


### PR DESCRIPTION
`uint32_t` is *un*signed

The description reads "Let's create a library that adds two signed 32-bit numbers".