### PR TITLE
Add ability to collapse sections

### DIFF
--- a/site/_includes/head.html
+++ b/site/_includes/head.html
@@ -10,4 +10,5 @@
   <link rel="canonical" href="{{ page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.url }}">
   <link rel="alternate" type="application/rss+xml" title="{{ site.title }}" href="{{ "/feed.xml" | prepend: site.baseurl | prepend: site.url }}" />
   <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.6/styles/github-gist.min.css">
+  <script src="{{ "/script/main.js" | prepend: site.baseurl }}"></script>
 </head>

--- a/site/css/main.scss
+++ b/site/css/main.scss
@@ -50,3 +50,22 @@ $on-laptop:        800px;
         "layout",
         "syntax-highlighting"
 ;
+
+@media (min-width: $on-laptop) {
+    .foldable {
+        cursor: pointer;
+        &:before {
+            content: "\2296 ";
+        }
+        &.folded {
+            &:before {
+                content: "\2295 ";
+            }
+            &+p, &+p+p, &+p+p+p, &+p+p+p+p, &+p+p+p+p+p,
+            &+pre, &+pre+p, &+pre+p+p, &+pre+p+p+p, &+pre+p+p+p+p,
+            &+pre+p+p+p+p+p, &+pre+p+p+p+p+p+p {
+                display: none;
+            }
+        }
+    }
+}

--- a/site/script/main.js
+++ b/site/script/main.js
@@ -1,0 +1,31 @@
+(function () {
+    "use strict";
+
+    var foldables = {c: 1, python: 1, ruby: 1, haskell: 1, nodejs: 1};
+    document.addEventListener('DOMContentLoaded', function () {
+        var titles = document.getElementsByTagName('h2');
+        for(var i=0; i<titles.length; ++i) {
+            var title = titles[i];
+            var id = title.getAttribute('id');
+            if (id in foldables) {
+                title.className += ' foldable';
+                if (localStorage.getItem(id)) {
+                    title.className += ' folded';
+                }
+            }
+        }
+    });
+    document.addEventListener('click', function (e) {
+        if (!(e && e.target && /\bfoldable\b/.test(e.target.className))) {
+            return;
+        }
+        var cls = e.target.className;
+        if (/\bfolded\b/.test(cls)) {
+            e.target.className = cls.replace(/\bfolded\b/, '');
+            localStorage.removeItem(e.target.getAttribute('id'));
+        } else {
+            e.target.className += ' folded';
+            localStorage.setItem(e.target.getAttribute('id'), 1);
+        }
+    });
+})();


### PR DESCRIPTION
Convenient when only interested in a single host language's FFI.

* didn't find a way to add classes to markdown, so list of "languages" (actually `h2/@id`) is coded in the script file
* saves collapse state to localStorage so it's remembered between pages and sessions
* only triggered on large screens (>800px), not sure that part's quite necessary
* assumes sections are a title (`h2`) followed by an optional code block (`pre`) and a bunch of paragraphs (limited to 6 at the moment)