### PR TITLE
Switch to Python 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ addons:
     packages:
       - ghc
       - mono-devel
+      - python3
 before_install:
 - bundle install
 script:

--- a/examples/integers/src/main.py
+++ b/examples/integers/src/main.py
@@ -9,4 +9,4 @@ lib = ctypes.cdll.LoadLibrary(prefix + "integers" + extension)
 lib.addition.argtypes = (c_uint32, c_uint32)
 lib.addition.restype = c_uint32
 
-print lib.addition(1, 2)
+print(lib.addition(1, 2))

--- a/examples/objects/src/main.py
+++ b/examples/objects/src/main.py
@@ -31,10 +31,10 @@ class ZipCodeDatabase:
         lib.zip_code_database_populate(self.obj)
 
     def population_of(self, zip):
-        return lib.zip_code_database_population_of(self.obj, zip)
+        return lib.zip_code_database_population_of(self.obj, zip.encode('utf-8'))
 
 with ZipCodeDatabase() as database:
     database.populate()
     pop1 = database.population_of("90210")
     pop2 = database.population_of("20500")
-    print pop1 - pop2
+    print(pop1 - pop2)

--- a/examples/slice_arguments/src/main.py
+++ b/examples/slice_arguments/src/main.py
@@ -14,4 +14,4 @@ def sum_of_even(numbers):
     buf = buf_type(*numbers)
     return lib.sum_of_even(buf, len(numbers))
 
-print sum_of_even([1,2,3,4,5,6])
+print(sum_of_even([1,2,3,4,5,6]))

--- a/examples/string_arguments/src/main.py
+++ b/examples/string_arguments/src/main.py
@@ -10,4 +10,4 @@ lib = ctypes.cdll.LoadLibrary(prefix + "string_arguments" + extension)
 lib.how_many_characters.argtypes = (c_char_p,)
 lib.how_many_characters.restype = c_uint32
 
-print lib.how_many_characters("göes to élevên")
+print(lib.how_many_characters("göes to élevên".encode('utf-8')))

--- a/examples/tests_python.mk
+++ b/examples/tests_python.mk
@@ -2,7 +2,7 @@ include ${COMMON_TEST_RULES}
 
 ${TEST_DIR_${d}}/python-test: LIB_DIR := ${LIB_DIR_${d}}
 ${TEST_DIR_${d}}/python-test: ${d}/src/main.py ${TEST_DIR_${d}} ${LIB_${d}}
-	LD_LIBRARY_PATH=${LIB_DIR} python $< > $@
+	LD_LIBRARY_PATH=${LIB_DIR} python3 $< > $@
 
 .PHONY: python-test_${d}
 python-test_${d}: EXPECTED := ${d}/expected-output

--- a/examples/tuples/src/main.py
+++ b/examples/tuples/src/main.py
@@ -17,4 +17,4 @@ lib.flip_things_around.restype = Tuple
 
 tup = Tuple(10, 20)
 
-print lib.flip_things_around(tup)
+print(lib.flip_things_around(tup))

--- a/site/basics/index.md
+++ b/site/basics/index.md
@@ -32,7 +32,7 @@ All Ruby examples will use Ruby 2.2 and the [FFI gem][gem].
 
 ## Python
 
-All Python examples will use Python 2.7 and the [ctypes library][ctypes].
+All Python examples will use Python 3.5 and the [ctypes library][ctypes].
 
 ## Haskell
 
@@ -72,5 +72,5 @@ installed.
 [libc]: http://doc.rust-lang.org/libc/libc/index.html
 [dyn-stat]: http://doc.crates.io/manifest.html#building-dynamic-or-static-libraries
 [gem]: https://github.com/ffi/ffi
-[ctypes]: https://docs.python.org/2/library/ctypes.html
+[ctypes]: https://docs.python.org/3/library/ctypes.html
 [node-ffi]: https://www.npmjs.com/package/node-ffi

--- a/site/string_arguments/index.md
+++ b/site/string_arguments/index.md
@@ -65,8 +65,8 @@ string.
 
 {% example src/main.py %}
 
-The ctypes library automatically converts Python strings to the
-appropriate C string.
+Python strings must be encoded as UTF-8 to be passed through the FFI
+boundary.
 
 ## Haskell
 


### PR DESCRIPTION
OS X 10.11's System Integrity Protection prevents passing
`LD_LIBRARY_PATH` to trusted binaries. The system-installed Python is in
this set, which means that it's very annoying for me to run tests. If I
have to use an installed Python version, it might as well be the new one.