### PR TITLE
[C Examples] printf integers properly

### DIFF
--- a/examples/integers/src/main.c
+++ b/examples/integers/src/main.c
@@ -5,6 +5,6 @@ extern uint32_t addition(uint32_t, uint32_t);
 
 int main(void) {
   uint32_t sum = addition(1, 2);
-  printf("%d\n", sum);
+  printf("%u\n", sum);
   return 0;
 }

--- a/examples/objects/src/main.c
+++ b/examples/objects/src/main.c
@@ -24,5 +24,5 @@ int main(void) {
 
   zip_code_database_free(database);
 
-  printf("%d\n", pop1 - pop2);
+  printf("%d\n", (int32_t)pop1 - (int32_t)pop2);
 }

--- a/examples/slice_arguments/src/main.c
+++ b/examples/slice_arguments/src/main.c
@@ -6,6 +6,6 @@ extern uint32_t sum_of_even(const uint32_t *numbers, size_t length);
 int main(void) {
   uint32_t numbers[6] = {1,2,3,4,5,6};
   uint32_t sum = sum_of_even(numbers, 6);
-  printf("%d\n", sum);
+  printf("%u\n", sum);
   return 0;
 }

--- a/examples/string_arguments/src/main.c
+++ b/examples/string_arguments/src/main.c
@@ -5,6 +5,6 @@ extern uint32_t how_many_characters(const char *str);
 
 int main(void) {
   uint32_t count = how_many_characters("göes to élevên");
-  printf("%d\n", count);
+  printf("%u\n", count);
   return 0;
 }

--- a/examples/tuples/src/main.c
+++ b/examples/tuples/src/main.c
@@ -11,6 +11,6 @@ extern tuple_t flip_things_around(tuple_t);
 int main(void) {
   tuple_t initial = { .x = 10, .y = 20 };
   tuple_t new = flip_things_around(initial);
-  printf("(%d,%d)\n", new.x, new.y);
+  printf("(%u,%u)\n", new.x, new.y);
   return 0;
 }


### PR DESCRIPTION
Resolves part of \#72.

- explicitly perform signed integer subtraction in "objects"
- use %u print flag to print values of type `uint32_t`