### PR TITLE
Fix c

### DIFF
--- a/examples/integers/src/main.c
+++ b/examples/integers/src/main.c
@@ -1,10 +1,11 @@
 #include <stdio.h>
 #include <stdint.h>
+#include <inttypes.h>
 
-extern uint32_t addition(uint32_t, uint32_t);
+extern uint32_t
+addition(uint32_t, uint32_t);
 
 int main(void) {
   uint32_t sum = addition(1, 2);
-  printf("%u\n", sum);
-  return 0;
+  printf("%" PRIu32 "\n", sum);
 }

--- a/examples/objects/src/main.c
+++ b/examples/objects/src/main.c
@@ -1,7 +1,8 @@
 #include <stdio.h>
 #include <stdint.h>
+#include <inttypes.h>
 
-typedef struct zip_code_database_S zip_code_database_t;
+typedef struct zip_code_database zip_code_database_t;
 
 extern zip_code_database_t *
 zip_code_database_new(void);
@@ -17,12 +18,12 @@ zip_code_database_population_of(const zip_code_database_t *, const char *zip);
 
 int main(void) {
   zip_code_database_t *database = zip_code_database_new();
-
   zip_code_database_populate(database);
+
   uint32_t pop1 = zip_code_database_population_of(database, "90210");
   uint32_t pop2 = zip_code_database_population_of(database, "20500");
 
   zip_code_database_free(database);
 
-  printf("%d\n", (int32_t)pop1 - (int32_t)pop2);
+  printf("%" PRId32 "\n", (int32_t)pop1 - (int32_t)pop2);
 }

--- a/examples/slice_arguments/src/main.c
+++ b/examples/slice_arguments/src/main.c
@@ -1,11 +1,13 @@
 #include <stdio.h>
 #include <stdint.h>
+#include <inttypes.h>
 
-extern uint32_t sum_of_even(const uint32_t *numbers, size_t length);
+extern uint32_t
+sum_of_even(const uint32_t *numbers, size_t length);
 
 int main(void) {
-  uint32_t numbers[6] = {1,2,3,4,5,6};
-  uint32_t sum = sum_of_even(numbers, 6);
-  printf("%u\n", sum);
-  return 0;
+  uint32_t numbers[] = {1, 2, 3, 4, 5, 6};
+  size_t length = sizeof numbers / sizeof *numbers;
+  uint32_t sum = sum_of_even(numbers, length);
+  printf("%" PRIu32 "\n", sum);
 }

--- a/examples/string_arguments/src/main.c
+++ b/examples/string_arguments/src/main.c
@@ -1,10 +1,11 @@
 #include <stdio.h>
+#include <stdint.h>
 #include <inttypes.h>
 
-extern uint32_t how_many_characters(const char *str);
+extern uint32_t
+how_many_characters(const char *str);
 
 int main(void) {
   uint32_t count = how_many_characters("göes to élevên");
-  printf("%u\n", count);
-  return 0;
+  printf("%" PRIu32 "\n", count);
 }

--- a/examples/tuples/src/main.c
+++ b/examples/tuples/src/main.c
@@ -1,16 +1,17 @@
 #include <stdio.h>
 #include <stdint.h>
+#include <inttypes.h>
 
 typedef struct {
   uint32_t x;
   uint32_t y;
 } tuple_t;
 
-extern tuple_t flip_things_around(tuple_t);
+extern tuple_t
+flip_things_around(tuple_t);
 
 int main(void) {
   tuple_t initial = { .x = 10, .y = 20 };
-  tuple_t new = flip_things_around(initial);
-  printf("(%u,%u)\n", new.x, new.y);
-  return 0;
+  tuple_t result = flip_things_around(initial);
+  printf("(%" PRIu32 ",%" PRIu32 ")\n", result.x, result.y);
 }

--- a/examples/vector_return/src/main.c
+++ b/examples/vector_return/src/main.c
@@ -1,5 +1,6 @@
 #include <stdio.h>
 #include <stdint.h>
+#include <inttypes.h>
 
 extern size_t
 counter_generate(size_t size, int16_t **vec);
@@ -9,15 +10,11 @@ counter_free(int16_t *vec, size_t size);
 
 int main(void) {
   int16_t *vec;
-  size_t vec_len;
-
-  vec_len = counter_generate(10, &vec);
-  for (int i = 0; i < 10; i++) {
-    printf("%hd..", vec[i]);
+  size_t vec_len = counter_generate(10, &vec);
+  for (size_t i = 0; i < vec_len; i++) {
+    printf("%" PRId16 "..", vec[i]);
   }
   printf("\n");
 
   counter_free(vec, vec_len);
-
-  return 0;
 }


### PR DESCRIPTION
- Use correct flags for fixed size integer types
- Use the same style in every C code
- Small change that improve code

These changes is primary motivated by the fact the actual code don't use the macro to print fixed size integer. According to the [standard](https://port70.net/~nsz/c/c11/n1570.html#B.7), you must use these.

I also removed the `_S` in `struct zip_code_database_S`, it's redondant.

The style was inconsistant, I stick the code to one.