### PR TITLE
Fix #60

### DIFF
--- a/examples/objects/src/main.py
+++ b/examples/objects/src/main.py
@@ -2,9 +2,12 @@
 
 import sys, ctypes
 from ctypes import c_char_p, c_uint32, Structure, POINTER
+from contextlib import contextmanager
+
 
 class ZipCodeDatabaseS(Structure):
     pass
+
 
 prefix = {'win32': ''}.get(sys.platform, 'lib')
 extension = {'darwin': '.dylib', 'win32': '.dll'}.get(sys.platform, '.so')
@@ -12,21 +15,19 @@ lib = ctypes.cdll.LoadLibrary(prefix + "objects" + extension)
 
 lib.zip_code_database_new.restype = POINTER(ZipCodeDatabaseS)
 
-lib.zip_code_database_free.argtypes = (POINTER(ZipCodeDatabaseS), )
+lib.zip_code_database_free.argtypes = (POINTER(ZipCodeDatabaseS),)
 
-lib.zip_code_database_populate.argtypes = (POINTER(ZipCodeDatabaseS), )
+lib.zip_code_database_populate.argtypes = (POINTER(ZipCodeDatabaseS),)
 
 lib.zip_code_database_population_of.argtypes = (POINTER(ZipCodeDatabaseS), c_char_p)
 lib.zip_code_database_population_of.restype = c_uint32
+
 
 class ZipCodeDatabase:
     def __init__(self):
         self.obj = lib.zip_code_database_new()
 
-    def __enter__(self):
-        return self
-
-    def __exit__(self, exc_type, exc_value, traceback):
+    def __del__(self):
         lib.zip_code_database_free(self.obj)
 
     def populate(self):
@@ -35,8 +36,16 @@ class ZipCodeDatabase:
     def population_of(self, zip):
         return lib.zip_code_database_population_of(self.obj, zip.encode('utf-8'))
 
-with ZipCodeDatabase() as database:
+
+@contextmanager
+def get_database():
+    resource = ZipCodeDatabase()
+    try: yield resource
+    finally: resource.__del__()
+
+
+with get_database() as database:
     database.populate()
     pop1 = database.population_of("90210")
     pop2 = database.population_of("20500")
-    print(pop1 - pop2)
+print(pop1 - pop2)


### PR DESCRIPTION
Implement both a context manager and a __del__ method for the python object example.

This allows the user to decide whether he wants the rust object to be de-allocated implicitly (and non-deterministically) when the python object is garbage-collected, or explicitly at the end of a python context.