### PR TITLE
Use built-in C# UTF-8 marshal method

### DIFF
--- a/examples/string_return/src/main.cs
+++ b/examples/string_return/src/main.cs
@@ -21,11 +21,7 @@ internal class ThemeSongHandle : SafeHandle
 
     public string AsString()
     {
-        int len = 0;
-        while (Marshal.ReadByte(handle, len) != 0) { ++len; }
-        byte[] buffer = new byte[len];
-        Marshal.Copy(handle, buffer, 0, buffer.Length);
-        return Encoding.UTF8.GetString(buffer);
+        return Marshal.PtrToStringUTF8(handle);
     }
 
     protected override bool ReleaseHandle()

--- a/site/string_return/index.md
+++ b/site/string_return/index.md
@@ -79,11 +79,6 @@ We follow a similar pattern to the object example: the Rust string is
 contained within a subclass of `SafeHandle` and a wrapper class
 `ThemeSong` ensures that the handle is disposed properly.
 
-Unfortunately, there is no easy way to read the pointer as a UTF-8
-string. C\# has cases for ANSI strings and for "Unicode" strings
-(really UCS-2), but nothing for UTF-8. We need to write that
-ourselves.
-
 ## Julia
 
 {% example src/main.jl %}


### PR DESCRIPTION
The "Passing Strings" example for C# states that marshalling UTF-8 strings must be done manually, but [Marshal.PtrToStringUTF8()](https://docs.microsoft.com/en-us/dotnet/api/system.runtime.interopservices.marshal.ptrtostringutf8?view=net-5.0&viewFallbackFrom=netframework-1.1) has been available since .NET 1.1. By not passing a length, it automatically detects null-terminated strings, so this can be shortened to one line.

(This diff compiles on Mono 6.12).