### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,5 +8,5 @@ Read [the contributing guidelines][contributing] for full
 information. For **this repository**, it is acceptable to add "+1"
 comments to vote for a specific issue.
 
-[omnibus]: http://jakegoulding.com/rust-ffi-omnibus/
+[omnibus]: https://jakegoulding.com/rust-ffi-omnibus/
 [contributing]: CONTRIBUTING.md


### PR DESCRIPTION
Just use https as default:

- http://jakegoulding.com/rust-ffi-omnibus/ doesn't redirect to https
- https should be default